### PR TITLE
Pass http.Request pointer to Authenticate

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -60,10 +60,10 @@ type API interface {
 type RequestMiddleware func(http.HandlerFunc) http.HandlerFunc
 
 // newAuthMiddleware returns a RequestMiddleware used to authenticate requests.
-func newAuthMiddleware(authenticate func(http.Request) error) RequestMiddleware {
+func newAuthMiddleware(authenticate func(*http.Request) error) RequestMiddleware {
 	return func(wrapped http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
-			if err := authenticate(*r); err != nil {
+			if err := authenticate(r); err != nil {
 				w.WriteHeader(http.StatusUnauthorized)
 				w.Write([]byte(err.Error()))
 				return

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -81,7 +81,7 @@ func (m *MockResourceHandler) DeleteResource(r RequestContext, id string,
 	return resource, args.Error(1)
 }
 
-func (m *MockResourceHandler) Authenticate(r http.Request) error {
+func (m *MockResourceHandler) Authenticate(r *http.Request) error {
 	args := m.Mock.Called()
 	return args.Error(0)
 }

--- a/rest/base_handler.go
+++ b/rest/base_handler.go
@@ -83,7 +83,7 @@ func (b BaseResourceHandler) DeleteResource(ctx RequestContext, id string,
 
 // Authenticate is the default authentication logic. All requests are authorized.
 // Implement custom authentication logic if necessary.
-func (b BaseResourceHandler) Authenticate(r http.Request) error {
+func (b BaseResourceHandler) Authenticate(r *http.Request) error {
 	return nil
 }
 

--- a/rest/example_simple_crud_test.go
+++ b/rest/example_simple_crud_test.go
@@ -99,7 +99,7 @@ func (f FooHandler) DeleteResource(ctx RequestContext, id string,
 // of Authenticate, seen in BaseResourceHandler, always returns nil, meaning
 // all requests are authenticated. Returning an error means that the request is
 // unauthorized and any error message will be sent back with the response.
-func (f FooHandler) Authenticate(r http.Request) error {
+func (f FooHandler) Authenticate(r *http.Request) error {
 	if secrets, ok := r.Header["Authorization"]; ok {
 		if secrets[0] == "secret" {
 			return nil

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -72,7 +72,7 @@ type ResourceHandler interface {
 	// of Authenticate, seen in BaseResourceHandler, always returns nil, meaning all
 	// requests are authenticated. Returning an error means that the request is
 	// unauthorized and any error message will be sent back with the response.
-	Authenticate(http.Request) error
+	Authenticate(*http.Request) error
 
 	// Rules returns the resource rules to apply to incoming requests and outgoing
 	// responses. The default behavior, seen in BaseResourceHandler, is to apply no


### PR DESCRIPTION
Pass the request pointer to Authenticate rather than the dereferenced
value. This is because certain auth libraries (e.g. go-http-auth)
require the pointer.

@rosshendrickson-wf @tannermiller-wf @stevenosborne-wf @alexandercampbell-wf @beaulyddon-wf @johnlockwood-wf
