### PR TITLE
Make http.Client pluggable in rest client

### DIFF
--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -66,10 +66,10 @@ func TestJSONMethods(t *testing.T) {
 
 	defer ts.Close()
 
-	var c = Client{testAuthorizer{
+	var c = NewClient(testAuthorizer{
 		"token",
 		"value",
-	}}
+	})
 
 	testObj := testObj{}
 	fs := []func() (*BaseResponse, error){


### PR DESCRIPTION
Most OAuth2 consumer libraries wrap authorization around the
http.Client. This makes the http.Client used by the rest Client
pluggable so that we can create an authorized client. In this case,
we just use a noop Authorizer since auth is handled by the client.

@stevenosborne-wf @tannermiller-wf @ericolson-wf @rosshendrickson-wf @beaulyddon-wf 
