### PR TITLE
Add Header method to Context

### DIFF
--- a/rest/context.go
+++ b/rest/context.go
@@ -103,6 +103,9 @@ type RequestContext interface {
 
 	// AddMessage adds a message to the request messages to be included in the response.
 	AddMessage(string)
+
+	// Header returns the header key-value pairs for the request.
+	Header() http.Header
 }
 
 // gorillaRequestContext is an implementation of the RequestContext interface. It wraps
@@ -243,6 +246,16 @@ func (ctx *gorillaRequestContext) Cursor() string {
 // setCursor sets the current result cursor for the request.
 func (ctx *gorillaRequestContext) setCursor(cursor string) RequestContext {
 	return ctx.WithValue(cursorKey, cursor)
+}
+
+// Header returns the header key-value pairs for the request.
+func (ctx *gorillaRequestContext) Header() http.Header {
+	req, ok := ctx.Request()
+	if !ok {
+		return http.Header{}
+	}
+
+	return req.Header
 }
 
 // Request returns the *http.Request associated with context using NewContext, if any.

--- a/rest/context_test.go
+++ b/rest/context_test.go
@@ -72,3 +72,12 @@ func TestMessagesWithError(t *testing.T) {
 		assert.Equal(errMessage, ctx.Messages()[1])
 	}
 }
+
+// Ensures that Header returns the request Header.
+func TestHeader(t *testing.T) {
+	assert := assert.New(t)
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	ctx := NewContext(nil, req)
+
+	assert.Equal(req.Header, ctx.Header())
+}


### PR DESCRIPTION
This is a convenience for accessing request headers through the context.

@stevenosborne-wf @beaulyddon-wf @rosshendrickson-wf @tannermiller-wf @ericolson-wf @alexandercampbell-wf 
