### PR TITLE
Unexport template strings

### DIFF
--- a/rest/doc.go
+++ b/rest/doc.go
@@ -149,7 +149,7 @@ func (d *docGenerator) generateDocs(api API) error {
 func (d *docGenerator) generateIndexDocs(docs map[string][]handlerDoc, versions []string,
 	dir string) error {
 
-	tpl, err := d.parse(IndexTemplate)
+	tpl, err := d.parse(indexTemplate)
 	if err != nil {
 		return err
 	}
@@ -174,7 +174,7 @@ func (d *docGenerator) generateIndexDocs(docs map[string][]handlerDoc, versions 
 func (d *docGenerator) generateHandlerDoc(handler ResourceHandler, version,
 	dir string) (handlerDoc, error) {
 
-	tpl, err := d.parse(HandlerTemplate)
+	tpl, err := d.parse(handlerTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/doc_test.go
+++ b/rest/doc_test.go
@@ -266,8 +266,8 @@ func TestGenerateDocsHandlesBadTemplate(t *testing.T) {
 	mockParser := new(mockTemplateParser)
 	mockContextGenerator := new(mockContextGenerator)
 	mockDocWriter := new(mockDocWriter)
-	mockParser.On("parse", IndexTemplate).Return(nil, fmt.Errorf("error"))
-	mockParser.On("parse", HandlerTemplate).Return(nil, fmt.Errorf("error"))
+	mockParser.On("parse", indexTemplate).Return(nil, fmt.Errorf("error"))
+	mockParser.On("parse", handlerTemplate).Return(nil, fmt.Errorf("error"))
 	mockDocWriter.On("mkdir", "_docs/", 0777).Return(nil)
 	docGenerator := &docGenerator{mockParser, mockContextGenerator, mockDocWriter}
 
@@ -306,8 +306,8 @@ func TestGenerateDocsWriteFail(t *testing.T) {
 	mockIndexTemplate := new(mockTemplateRenderer)
 	mockHandlerTemplate := new(mockTemplateRenderer)
 
-	mockParser.On("parse", IndexTemplate).Return(mockIndexTemplate, nil)
-	mockParser.On("parse", HandlerTemplate).Return(mockHandlerTemplate, nil)
+	mockParser.On("parse", indexTemplate).Return(mockIndexTemplate, nil)
+	mockParser.On("parse", handlerTemplate).Return(mockHandlerTemplate, nil)
 
 	fooV1Rendered := "foov1"
 	barV1Rendered := "barv1"
@@ -361,7 +361,7 @@ func TestGenerateDocsGenerateFail(t *testing.T) {
 	mockDocWriter := new(mockDocWriter)
 	mockHandlerTemplate := new(mockTemplateRenderer)
 
-	mockParser.On("parse", HandlerTemplate).Return(mockHandlerTemplate, nil)
+	mockParser.On("parse", handlerTemplate).Return(mockHandlerTemplate, nil)
 
 	fooV1Rendered := "foov1"
 	mockHandlerTemplate.On("render", fooV1Context).Return(fooV1Rendered).Once()
@@ -393,8 +393,8 @@ func TestGenerateDocsHappyPath(t *testing.T) {
 	mockIndexTemplate := new(mockTemplateRenderer)
 	mockHandlerTemplate := new(mockTemplateRenderer)
 
-	mockParser.On("parse", IndexTemplate).Return(mockIndexTemplate, nil)
-	mockParser.On("parse", HandlerTemplate).Return(mockHandlerTemplate, nil)
+	mockParser.On("parse", indexTemplate).Return(mockIndexTemplate, nil)
+	mockParser.On("parse", handlerTemplate).Return(mockHandlerTemplate, nil)
 
 	fooV1Rendered := "foov1"
 	barV1Rendered := "barv1"

--- a/rest/handler_tpl.go
+++ b/rest/handler_tpl.go
@@ -1,7 +1,7 @@
 package rest
 
-// HandlerTemplate is the mustache template for the handler documentation.
-const HandlerTemplate = `
+// handlerTemplate is the mustache template for the handler documentation.
+const handlerTemplate = `
 <!DOCTYPE HTML>
 <html lang="en">
     <head>

--- a/rest/index_tpl.go
+++ b/rest/index_tpl.go
@@ -1,7 +1,7 @@
 package rest
 
-// IndexTemplate is the mustache template for the documentation index.
-const IndexTemplate = `
+// indexTemplate is the mustache template for the documentation index.
+const indexTemplate = `
 <!DOCTYPE HTML>
 <html lang="en">
     <head>


### PR DESCRIPTION
Unexport the templates used to render documentation.

@stevenosborne-wf @tannermiller-wf @alexandercampbell-wf @rosshendrickson-wf @beaulyddon-wf @dustinhiatt-wf @ericolson-wf @johnlockwood-wf
