### PR TITLE
Fix debug logging output

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -49,7 +49,7 @@ type Configuration struct {
 // Debugf prints the formatted string to the Configuration Logger if Debug is enabled.
 func (c *Configuration) Debugf(format string, v ...interface{}) {
 	if c.Debug {
-		c.Logger.Printf(format, v)
+		c.Logger.Printf(format, v...)
 	}
 }
 


### PR DESCRIPTION
Debug parameters were missing `...` and resulted in errant logging messages like this:

```
rest 2015/04/07 17:21:19 Registered [read override /api/v{version:[^/]+}/analytics OVERRIDE-GET] handler at %!s(MISSING) %!s(MISSING)
```
