### PR TITLE
Fix issue #37

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -126,7 +126,7 @@ func (r *muxAPI) getRouteHandler(name string) (http.Handler, error) {
 	return route.GetHandler(), nil
 }
 
-// Ensures that the create handler returns a Not Implemented code if an invalid response
+// Ensures that the create handler returns a Bad Request code if an invalid response
 // format is provided.
 func TestHandleCreateBadFormat(t *testing.T) {
 	assert := assert.New(t)
@@ -149,9 +149,9 @@ func TestHandleCreateBadFormat(t *testing.T) {
 	createHandler.ServeHTTP(resp, req)
 
 	handler.Mock.AssertExpectations(t)
-	assert.Equal(http.StatusNotImplemented, resp.Code, "Incorrect response code")
+	assert.Equal(http.StatusBadRequest, resp.Code, "Incorrect response code")
 	assert.Equal(
-		`{"messages":["Format not implemented: blah"],"reason":"Not Implemented","status":501}`,
+		`{"messages":["Format not implemented: blah"],"reason":"Bad Request","status":400}`,
 		resp.Body.String(),
 		"Incorrect response string",
 	)
@@ -244,7 +244,7 @@ func TestHandleCreateNotAuthorized(t *testing.T) {
 	assert.Equal("Not authorized", resp.Body.String(), "Incorrect response string")
 }
 
-// Ensures that the read list handler returns a Not Implemented code if an invalid response
+// Ensures that the read list handler returns a Bad Request code if an invalid response
 // format is provided.
 func TestHandleReadListBadFormat(t *testing.T) {
 	assert := assert.New(t)
@@ -265,9 +265,9 @@ func TestHandleReadListBadFormat(t *testing.T) {
 	readHandler.ServeHTTP(resp, req)
 
 	handler.Mock.AssertExpectations(t)
-	assert.Equal(http.StatusNotImplemented, resp.Code, "Incorrect response code")
+	assert.Equal(http.StatusBadRequest, resp.Code, "Incorrect response code")
 	assert.Equal(
-		`{"messages":["Format not implemented: blah"],"reason":"Not Implemented","status":501}`,
+		`{"messages":["Format not implemented: blah"],"reason":"Bad Request","status":400}`,
 		resp.Body.String(),
 		"Incorrect response string",
 	)
@@ -330,7 +330,7 @@ func TestHandleReadListHappyPath(t *testing.T) {
 	)
 }
 
-// Ensures that the read handler returns a Not Implemented code if an invalid response format is provided.
+// Ensures that the read handler returns a Bad Request code if an invalid response format is provided.
 func TestHandleReadBadFormat(t *testing.T) {
 	assert := assert.New(t)
 	handler := new(MockResourceHandler)
@@ -350,9 +350,9 @@ func TestHandleReadBadFormat(t *testing.T) {
 	readHandler.ServeHTTP(resp, req)
 
 	handler.Mock.AssertExpectations(t)
-	assert.Equal(http.StatusNotImplemented, resp.Code, "Incorrect response code")
+	assert.Equal(http.StatusBadRequest, resp.Code, "Incorrect response code")
 	assert.Equal(
-		`{"messages":["Format not implemented: blah"],"reason":"Not Implemented","status":501}`,
+		`{"messages":["Format not implemented: blah"],"reason":"Bad Request","status":400}`,
 		resp.Body.String(),
 		"Incorrect response string",
 	)
@@ -414,7 +414,7 @@ func TestHandleReadHappyPath(t *testing.T) {
 	)
 }
 
-// Ensures that the update list handler returns a Not Implemented code if an invalid response format
+// Ensures that the update list handler returns a Bad Request code if an invalid response format
 // is provided.
 func TestHandleUpdateListBadFormat(t *testing.T) {
 	assert := assert.New(t)
@@ -437,9 +437,9 @@ func TestHandleUpdateListBadFormat(t *testing.T) {
 	updateHandler.ServeHTTP(resp, req)
 
 	handler.Mock.AssertExpectations(t)
-	assert.Equal(http.StatusNotImplemented, resp.Code, "Incorrect response code")
+	assert.Equal(http.StatusBadRequest, resp.Code, "Incorrect response code")
 	assert.Equal(
-		`{"messages":["Format not implemented: blah"],"reason":"Not Implemented","status":501}`,
+		`{"messages":["Format not implemented: blah"],"reason":"Bad Request","status":400}`,
 		resp.Body.String(),
 		"Incorrect response string",
 	)
@@ -537,7 +537,7 @@ func TestHandleUpdateListHappyPath(t *testing.T) {
 	)
 }
 
-// Ensures that the update handler returns a Not Implemented code if an invalid response format is provided.
+// Ensures that the update handler returns a Bad Request code if an invalid response format is provided.
 func TestHandleUpdateBadFormat(t *testing.T) {
 	assert := assert.New(t)
 	handler := new(MockResourceHandler)
@@ -559,9 +559,9 @@ func TestHandleUpdateBadFormat(t *testing.T) {
 	updateHandler.ServeHTTP(resp, req)
 
 	handler.Mock.AssertExpectations(t)
-	assert.Equal(http.StatusNotImplemented, resp.Code, "Incorrect response code")
+	assert.Equal(http.StatusBadRequest, resp.Code, "Incorrect response code")
 	assert.Equal(
-		`{"messages":["Format not implemented: blah"],"reason":"Not Implemented","status":501}`,
+		`{"messages":["Format not implemented: blah"],"reason":"Bad Request","status":400}`,
 		resp.Body.String(),
 		"Incorrect response string",
 	)
@@ -628,7 +628,7 @@ func TestHandleUpdateHappyPath(t *testing.T) {
 	)
 }
 
-// Ensures that the delete handler returns a Not Implemented code if an invalid response format is
+// Ensures that the delete handler returns a Bad Request code if an invalid response format is
 // provided.
 func TestHandleDeleteBadFormat(t *testing.T) {
 	assert := assert.New(t)
@@ -649,9 +649,9 @@ func TestHandleDeleteBadFormat(t *testing.T) {
 	deleteHandler.ServeHTTP(resp, req)
 
 	handler.Mock.AssertExpectations(t)
-	assert.Equal(http.StatusNotImplemented, resp.Code, "Incorrect response code")
+	assert.Equal(http.StatusBadRequest, resp.Code, "Incorrect response code")
 	assert.Equal(
-		`{"messages":["Format not implemented: blah"],"reason":"Not Implemented","status":501}`,
+		`{"messages":["Format not implemented: blah"],"reason":"Bad Request","status":400}`,
 		resp.Body.String(),
 		"Incorrect response string",
 	)

--- a/rest/base_handler.go
+++ b/rest/base_handler.go
@@ -100,37 +100,37 @@ func (b BaseResourceHandler) DeleteDocumentation() string {
 // CreateResource is a stub. Implement if necessary.
 func (b BaseResourceHandler) CreateResource(ctx RequestContext, data Payload,
 	version string) (Resource, error) {
-	return nil, NotImplemented("CreateResource is not implemented")
+	return nil, MethodNotAllowed("CreateResource is not implemented")
 }
 
 // ReadResourceList is a stub. Implement if necessary.
 func (b BaseResourceHandler) ReadResourceList(ctx RequestContext, limit int,
 	cursor string, version string) ([]Resource, string, error) {
-	return nil, "", NotImplemented("ReadResourceList not implemented")
+	return nil, "", MethodNotAllowed("ReadResourceList not implemented")
 }
 
 // ReadResource is a stub. Implement if necessary.
 func (b BaseResourceHandler) ReadResource(ctx RequestContext, id string,
 	version string) (Resource, error) {
-	return nil, NotImplemented("ReadResource not implemented")
+	return nil, MethodNotAllowed("ReadResource not implemented")
 }
 
 // UpdateResourceList is a stub. Implement if necessary.
 func (b BaseResourceHandler) UpdateResourceList(ctx RequestContext, data []Payload,
 	version string) ([]Resource, error) {
-	return nil, NotImplemented("UpdateResourceList not implemented")
+	return nil, MethodNotAllowed("UpdateResourceList not implemented")
 }
 
 // UpdateResource is a stub. Implement if necessary.
 func (b BaseResourceHandler) UpdateResource(ctx RequestContext, id string,
 	data Payload, version string) (Resource, error) {
-	return nil, NotImplemented("UpdateResource not implemented")
+	return nil, MethodNotAllowed("UpdateResource not implemented")
 }
 
 // DeleteResource is a stub. Implement if necessary.
 func (b BaseResourceHandler) DeleteResource(ctx RequestContext, id string,
 	version string) (Resource, error) {
-	return nil, NotImplemented("DeleteResource not implemented")
+	return nil, MethodNotAllowed("DeleteResource not implemented")
 }
 
 // Authenticate is the default authentication logic. All requests are authorized.

--- a/rest/errors.go
+++ b/rest/errors.go
@@ -18,6 +18,10 @@ package rest
 
 import "net/http"
 
+// statusUnprocessableEntity indicates the request was well-formed but was
+// unable to be followed due to semantic errors.
+const statusUnprocessableEntity = 422
+
 // Error is an implementation of the error interface representing an HTTP error.
 type Error struct {
 	reason string
@@ -52,7 +56,7 @@ func BadRequest(reason string) Error {
 
 // UnprocessableRequest returns a Error for a 422 Unprocessable Entity error.
 func UnprocessableRequest(reason string) Error {
-	return Error{reason, 422}
+	return Error{reason, statusUnprocessableEntity}
 }
 
 // UnauthorizedRequest returns a Error for a 401 Unauthorized error.
@@ -60,9 +64,9 @@ func UnauthorizedRequest(reason string) Error {
 	return Error{reason, http.StatusUnauthorized}
 }
 
-// NotImplemented returns a Error for a 501 Not Implemented error.
-func NotImplemented(reason string) Error {
-	return Error{reason, http.StatusNotImplemented}
+// MethodNotAllowed returns a Error for a 405 Method Not Allowed error.
+func MethodNotAllowed(reason string) Error {
+	return Error{reason, http.StatusMethodNotAllowed}
 }
 
 // InternalServerError returns a Error for a 500 Internal Server error.

--- a/rest/errors_test.go
+++ b/rest/errors_test.go
@@ -45,15 +45,15 @@ func TestErrors(t *testing.T) {
 
 	err = UnprocessableRequest("foo")
 	assert.Equal("foo", err.Error())
-	assert.Equal(422, err.Status())
+	assert.Equal(statusUnprocessableEntity, err.Status())
 
 	err = UnauthorizedRequest("foo")
 	assert.Equal("foo", err.Error())
 	assert.Equal(http.StatusUnauthorized, err.Status())
 
-	err = NotImplemented("foo")
+	err = MethodNotAllowed("foo")
 	assert.Equal("foo", err.Error())
-	assert.Equal(http.StatusNotImplemented, err.Status())
+	assert.Equal(http.StatusMethodNotAllowed, err.Status())
 
 	err = ResourceNotPermitted("foo")
 	assert.Equal("foo", err.Error())

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -328,7 +328,7 @@ func (h requestHandler) sendResponse(w http.ResponseWriter, ctx RequestContext) 
 	if err != nil {
 		// Fall back to json serialization.
 		serializer = jsonSerializer{}
-		ctx = ctx.setError(NotImplemented(fmt.Sprintf("Format not implemented: %s", format)))
+		ctx = ctx.setError(BadRequest(fmt.Sprintf("Format not implemented: %s", format)))
 	}
 
 	sendResponse(w, NewResponse(ctx), serializer)


### PR DESCRIPTION
Use HTTP 405 for HTTP methods that don't have a handler instead of 501.
Also use 400 Bad Request for requests which specify an invalid response
format.

@aaronkavlie-wf @stevenosborne-wf @alexandercampbell-wf 