### PR TITLE
Modify middleware to work with http.Handlers

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -715,11 +715,11 @@ func TestHandleDeleteHappyPath(t *testing.T) {
 }
 
 func getMiddleware(called *bool) RequestMiddleware {
-	return func(h http.HandlerFunc) http.HandlerFunc {
-		return func(w http.ResponseWriter, r *http.Request) {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			*called = true
-			h(w, r)
-		}
+			h.ServeHTTP(w, r)
+		})
 	}
 }
 

--- a/rest/example_middleware_test.go
+++ b/rest/example_middleware_test.go
@@ -69,12 +69,12 @@ func (e MiddlewareHandler) ReadResource(ctx RequestContext, id string, version s
 }
 
 // ResourceHandler middleware is implemented as a closure which takes an
-// http.HandlerFunc and returns one.
-func HandlerMiddleware(wrapped http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+// http.Handler and returns one.
+func HandlerMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Request: %s", r.URL.String())
-		wrapped(w, r)
-	}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // Global API middleware is implemented as a function which takes an

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -129,8 +129,8 @@ type requestHandler struct {
 // handleCreate returns a HandlerFunc which will deserialize the request payload, pass
 // it to the provided create function, and then serialize and dispatch the response.
 // The serialization mechanism used is specified by the "format" query parameter.
-func (h requestHandler) handleCreate(handler ResourceHandler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func (h requestHandler) handleCreate(handler ResourceHandler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := NewContext(nil, r)
 		version := ctx.Version()
 		rules := handler.Rules()
@@ -159,14 +159,14 @@ func (h requestHandler) handleCreate(handler ResourceHandler) http.HandlerFunc {
 		}
 
 		h.sendResponse(w, ctx)
-	}
+	})
 }
 
-// handleReadList returns a HandlerFunc which will pass the request context to the
+// handleReadList returns a Handler which will pass the request context to the
 // provided read function and then serialize and dispatch the response. The
 // serialization mechanism used is specified by the "format" query parameter.
-func (h requestHandler) handleReadList(handler ResourceHandler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func (h requestHandler) handleReadList(handler ResourceHandler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := NewContext(nil, r)
 		version := ctx.Version()
 		rules := handler.Rules()
@@ -187,14 +187,14 @@ func (h requestHandler) handleReadList(handler ResourceHandler) http.HandlerFunc
 		ctx = ctx.setStatus(http.StatusOK)
 
 		h.sendResponse(w, ctx)
-	}
+	})
 }
 
-// handleRead returns a HandlerFunc which will pass the resource id to the provided
+// handleRead returns a Handler which will pass the resource id to the provided
 // read function and then serialize and dispatch the response. The serialization
 // mechanism used is specified by the "format" query parameter.
-func (h requestHandler) handleRead(handler ResourceHandler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func (h requestHandler) handleRead(handler ResourceHandler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := NewContext(nil, r)
 		version := ctx.Version()
 		rules := handler.Rules()
@@ -209,15 +209,15 @@ func (h requestHandler) handleRead(handler ResourceHandler) http.HandlerFunc {
 		ctx = ctx.setStatus(http.StatusOK)
 
 		h.sendResponse(w, ctx)
-	}
+	})
 }
 
-// handleUpdateList returns a HandlerFunc which will deserialize the request payload,
+// handleUpdateList returns a Handler which will deserialize the request payload,
 // pass it to the provided update function, and then serialize and dispatch the
 // response. The serialization mechanism used is specified by the "format" query
 // parameter.
-func (h requestHandler) handleUpdateList(handler ResourceHandler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func (h requestHandler) handleUpdateList(handler ResourceHandler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := NewContext(nil, r)
 		version := ctx.Version()
 		rules := handler.Rules()
@@ -258,15 +258,15 @@ func (h requestHandler) handleUpdateList(handler ResourceHandler) http.HandlerFu
 		}
 
 		h.sendResponse(w, ctx)
-	}
+	})
 }
 
-// handleUpdate returns a HandlerFunc which will deserialize the request payload,
+// handleUpdate returns a Handler which will deserialize the request payload,
 // pass it to the provided update function, and then serialize and dispatch the
 // response. The serialization mechanism used is specified by the "format" query
 // parameter.
-func (h requestHandler) handleUpdate(handler ResourceHandler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func (h requestHandler) handleUpdate(handler ResourceHandler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := NewContext(nil, r)
 		version := ctx.Version()
 		rules := handler.Rules()
@@ -295,14 +295,14 @@ func (h requestHandler) handleUpdate(handler ResourceHandler) http.HandlerFunc {
 		}
 
 		h.sendResponse(w, ctx)
-	}
+	})
 }
 
-// handleDelete returns a HandlerFunc which will pass the resource id to the provided
+// handleDelete returns a Handler which will pass the resource id to the provided
 // delete function and then serialize and dispatch the response. The serialization
 // mechanism used is specified by the "format" query parameter.
-func (h requestHandler) handleDelete(handler ResourceHandler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func (h requestHandler) handleDelete(handler ResourceHandler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := NewContext(nil, r)
 		version := ctx.Version()
 		rules := handler.Rules()
@@ -317,7 +317,7 @@ func (h requestHandler) handleDelete(handler ResourceHandler) http.HandlerFunc {
 		ctx = ctx.setStatus(http.StatusOK)
 
 		h.sendResponse(w, ctx)
-	}
+	})
 }
 
 // sendResponse writes a success or error response to the provided http.ResponseWriter


### PR DESCRIPTION
`RequestMiddleware` currently works on the `http.HandlerFunc` type, rather than the `http.Handler` interface that it implements. 

Most middleware out in the wild, such as the [Gorilla handlers package](http://www.gorillatoolkit.org/pkg/handlers), uses `http.Handler` types. Current implementation prevents us from using this middleware (the `LoggingHandler` is of interest to me).

Middleware written against the old API would require some modification; see [changes to the example code](https://github.com/Workiva/go-rest/blob/6ab52aaaaa0730f1694a2cec1fc392e3b81fbafa/rest/example_middleware_test.go#L73-L78). If this PR looks good otherwise, we'll have to make sure existing users aren't adversely impacted.

@tylertreat-wf @stevenosborne-wf @alexandercampbell-wf 
