### PR TITLE
Add CustomError for user-provided status code

### DIFF
--- a/rest/errors.go
+++ b/rest/errors.go
@@ -73,3 +73,8 @@ func MethodNotAllowed(reason string) Error {
 func InternalServerError(reason string) Error {
 	return Error{reason, http.StatusInternalServerError}
 }
+
+// CustomError returns an Error for the given HTTP status code.
+func CustomError(reason string, status int) Error {
+	return Error{reason, status}
+}


### PR DESCRIPTION
I need to return a *503 Service Unavailable* status code, and go-rest didn't have an error for that.

Rather than another one-off error for my use case, I thought it would be useful to allow the creation of an error for any status code go-rest doesn't cover with the existing error functions.

I'm not in love with the `CustomError` name, if you have a better idea I'm happy to change it.

@tylertreat-wf 