### PR TITLE
Update import path for the context package

### DIFF
--- a/rest/context.go
+++ b/rest/context.go
@@ -22,9 +22,9 @@ import (
 	"net/url"
 	"strconv"
 
-	"code.google.com/p/go.net/context"
 	gcontext "github.com/gorilla/context"
 	"github.com/gorilla/mux"
+	"golang.org/x/net/context"
 )
 
 const (


### PR DESCRIPTION
Godep doesn't work with `code.google.com` imports.
This just updates the [context package](https://godoc.org/golang.org/x/net/context) to its new import path.

@tylertreat-wf @alexandercampbell-wf 
