### PR TITLE
Allow 204 response (with blank body) for POST requests

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -344,8 +344,8 @@ func sendResponse(w http.ResponseWriter, r response, serializer ResponseSerializ
 	contentType := serializer.ContentType()
 
 	var response []byte
-	var err error
 	if r.Payload != nil {
+		var err error
 		response, err = serializer.Serialize(r.Payload)
 		if err != nil {
 			log.Printf("Response serialization failed: %s", err)

--- a/rest/serialize.go
+++ b/rest/serialize.go
@@ -83,20 +83,21 @@ func newSuccessResponse(ctx RequestContext) response {
 	}
 
 	s := ctx.Status()
-	payload := Payload{
-		status:    s,
-		reason:    http.StatusText(s),
-		messages:  ctx.Messages(),
-		resultKey: r,
-	}
+	response := response{Status: s}
 
-	if nextURL, err := ctx.NextURL(); err == nil && nextURL != "" {
-		payload[next] = nextURL
-	}
+	if s != http.StatusNoContent {
+		payload := Payload{
+			status:    s,
+			reason:    http.StatusText(s),
+			messages:  ctx.Messages(),
+			resultKey: r,
+		}
 
-	response := response{
-		Payload: payload,
-		Status:  s,
+		if nextURL, err := ctx.NextURL(); err == nil && nextURL != "" {
+			payload[next] = nextURL
+		}
+
+		response.Payload = payload
 	}
 
 	return response


### PR DESCRIPTION
This PR modifies `handleCreate` to omit the body and set status code 204 if the user passes a `nil` Resource.

@tylertreat-wf @alexandercampbell-wf 