### PR TITLE
URL generation for named routes

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -159,6 +159,8 @@ type API interface {
 	// responseSerializer returns a ResponseSerializer for the given format type. If the
 	// format is not implemented, the returned serializer will be nil and the error set.
 	responseSerializer(string) (ResponseSerializer, error)
+
+	Router() *mux.Router
 }
 
 // RequestMiddleware is a function that returns a Handler wrapping the provided Handler.
@@ -188,6 +190,10 @@ type muxAPI struct {
 	handler            *requestHandler
 	serializerRegistry map[string]ResponseSerializer
 	resourceHandlers   []ResourceHandler
+}
+
+func (r *muxAPI) Router() *mux.Router {
+	return r.router
 }
 
 // NewAPI returns a newly allocated API instance.

--- a/rest/api.go
+++ b/rest/api.go
@@ -35,11 +35,11 @@ const (
 
 	// Handler names
 	HandleCreate     HandleMethod = "create"
-	HandleRead       HandleMethod = "read"
-	HandleUpdate     HandleMethod = "update"
-	HandleDelete     HandleMethod = "delete"
-	HandleReadList   HandleMethod = "readList"
-	HandleUpdateList HandleMethod = "updateList"
+	HandleRead                    = "read"
+	HandleUpdate                  = "update"
+	HandleDelete                  = "delete"
+	HandleReadList                = "readList"
+	HandleUpdateList              = "updateList"
 )
 
 // Address is the address and port to bind to (e.g. ":8080").

--- a/rest/api.go
+++ b/rest/api.go
@@ -27,17 +27,19 @@ import (
 	"github.com/gorilla/mux"
 )
 
+type HandleMethod string
+
 const (
 	defaultLogPrefix     = "rest "
 	defaultDocsDirectory = "_docs/"
 
 	// Handler names
-	HandleCreate     = "create"
-	HandleRead       = "read"
-	HandleUpdate     = "update"
-	HandleDelete     = "delete"
-	HandleReadList   = "readList"
-	HandleUpdateList = "updateList"
+	HandleCreate     HandleMethod = "create"
+	HandleRead       HandleMethod = "read"
+	HandleUpdate     HandleMethod = "update"
+	HandleDelete     HandleMethod = "delete"
+	HandleReadList   HandleMethod = "readList"
+	HandleUpdateList HandleMethod = "updateList"
 )
 
 // Address is the address and port to bind to (e.g. ":8080").
@@ -286,32 +288,32 @@ func (r *muxAPI) RegisterResourceHandler(h ResourceHandler, middleware ...Reques
 	// that and log it if it fails :)
 	r.router.Handle(
 		h.CreateURI(), applyMiddleware(r.handler.handleCreate(h), middleware),
-	).Methods("POST").Name(resource + ":" + HandleCreate)
+	).Methods("POST").Name(resource + ":" + string(HandleCreate))
 	r.checkRoute("create", h.CreateURI(), "POST", route)
 
 	r.router.Handle(
 		h.ReadListURI(), applyMiddleware(r.handler.handleReadList(h), middleware),
-	).Methods("GET").Name(resource + ":" + HandleReadList)
+	).Methods("GET").Name(resource + ":" + string(HandleReadList))
 	r.checkRoute("read list", h.ReadListURI(), "GET", route)
 
 	r.router.Handle(
 		h.ReadURI(), applyMiddleware(r.handler.handleRead(h), middleware),
-	).Methods("GET").Name(resource + ":" + HandleRead)
+	).Methods("GET").Name(resource + ":" + string(HandleRead))
 	r.checkRoute("read", h.ReadURI(), "GET", route)
 
 	r.router.Handle(
 		h.UpdateListURI(), applyMiddleware(r.handler.handleUpdateList(h), middleware),
-	).Methods("PUT").Name(resource + ":" + HandleUpdateList)
+	).Methods("PUT").Name(resource + ":" + string(HandleUpdateList))
 	r.checkRoute("update list", h.UpdateListURI(), "PUT", route)
 
 	r.router.Handle(
 		h.UpdateURI(), applyMiddleware(r.handler.handleUpdate(h), middleware),
-	).Methods("PUT").Name(resource + ":" + HandleUpdate)
+	).Methods("PUT").Name(resource + ":" + string(HandleUpdate))
 	r.checkRoute("update", h.UpdateURI(), "PUT", route)
 
 	r.router.Handle(
 		h.DeleteURI(), applyMiddleware(r.handler.handleDelete(h), middleware),
-	).Methods("DELETE").Name(resource + ":" + HandleDelete)
+	).Methods("DELETE").Name(resource + ":" + string(HandleDelete))
 	r.checkRoute("delete", h.DeleteURI(), "DELETE", route)
 
 	r.resourceHandlers = append(r.resourceHandlers, h)

--- a/rest/api.go
+++ b/rest/api.go
@@ -159,8 +159,6 @@ type API interface {
 	// responseSerializer returns a ResponseSerializer for the given format type. If the
 	// format is not implemented, the returned serializer will be nil and the error set.
 	responseSerializer(string) (ResponseSerializer, error)
-
-	Router() *mux.Router
 }
 
 // RequestMiddleware is a function that returns a Handler wrapping the provided Handler.
@@ -192,10 +190,6 @@ type muxAPI struct {
 	resourceHandlers   []ResourceHandler
 }
 
-func (r *muxAPI) Router() *mux.Router {
-	return r.router
-}
-
 // NewAPI returns a newly allocated API instance.
 func NewAPI(config *Configuration) API {
 	r := mux.NewRouter()
@@ -205,7 +199,7 @@ func NewAPI(config *Configuration) API {
 		serializerRegistry: map[string]ResponseSerializer{"json": &jsonSerializer{}},
 		resourceHandlers:   make([]ResourceHandler, 0),
 	}
-	restAPI.handler = &requestHandler{restAPI}
+	restAPI.handler = &requestHandler{restAPI, r}
 	return restAPI
 }
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -30,6 +30,14 @@ import (
 const (
 	defaultLogPrefix     = "rest "
 	defaultDocsDirectory = "_docs/"
+
+	// Handler names
+	HandleCreate     = "create"
+	HandleRead       = "read"
+	HandleUpdate     = "update"
+	HandleDelete     = "delete"
+	HandleReadList   = "readList"
+	HandleUpdateList = "updateList"
 )
 
 // Address is the address and port to bind to (e.g. ":8080").
@@ -278,32 +286,32 @@ func (r *muxAPI) RegisterResourceHandler(h ResourceHandler, middleware ...Reques
 	// that and log it if it fails :)
 	r.router.Handle(
 		h.CreateURI(), applyMiddleware(r.handler.handleCreate(h), middleware),
-	).Methods("POST").Name(resource + ":create")
+	).Methods("POST").Name(resource + ":" + HandleCreate)
 	r.checkRoute("create", h.CreateURI(), "POST", route)
 
 	r.router.Handle(
 		h.ReadListURI(), applyMiddleware(r.handler.handleReadList(h), middleware),
-	).Methods("GET").Name(resource + ":readList")
+	).Methods("GET").Name(resource + ":" + HandleReadList)
 	r.checkRoute("read list", h.ReadListURI(), "GET", route)
 
 	r.router.Handle(
 		h.ReadURI(), applyMiddleware(r.handler.handleRead(h), middleware),
-	).Methods("GET").Name(resource + ":read")
+	).Methods("GET").Name(resource + ":" + HandleRead)
 	r.checkRoute("read", h.ReadURI(), "GET", route)
 
 	r.router.Handle(
 		h.UpdateListURI(), applyMiddleware(r.handler.handleUpdateList(h), middleware),
-	).Methods("PUT").Name(resource + ":updateList")
+	).Methods("PUT").Name(resource + ":" + HandleUpdateList)
 	r.checkRoute("update list", h.UpdateListURI(), "PUT", route)
 
 	r.router.Handle(
 		h.UpdateURI(), applyMiddleware(r.handler.handleUpdate(h), middleware),
-	).Methods("PUT").Name(resource + ":update")
+	).Methods("PUT").Name(resource + ":" + HandleUpdate)
 	r.checkRoute("update", h.UpdateURI(), "PUT", route)
 
 	r.router.Handle(
 		h.DeleteURI(), applyMiddleware(r.handler.handleDelete(h), middleware),
-	).Methods("DELETE").Name(resource + ":delete")
+	).Methods("DELETE").Name(resource + ":" + HandleDelete)
 	r.checkRoute("delete", h.DeleteURI(), "DELETE", route)
 
 	r.resourceHandlers = append(r.resourceHandlers, h)

--- a/rest/context.go
+++ b/rest/context.go
@@ -342,15 +342,9 @@ func (ctx *gorillaRequestContext) BuildURL(routeName, resourceID string) (string
 			routeName, resourceID)
 	}
 
-	scheme := "http"
-	if r.TLS != nil {
-		scheme += "s"
-	}
-
 	// Need a way to get route name without knowledge of go-rest internals
 	// routeName := resourceName + ":read"
-	uri, err := ctx.router.Get(routeName).
-		Schemes(scheme).
+	url, err := ctx.router.Get(routeName).
 		Host(r.Host).
 		URL("version", ctx.Version(),
 		"resource_id", resourceID)
@@ -358,7 +352,11 @@ func (ctx *gorillaRequestContext) BuildURL(routeName, resourceID string) (string
 		return "", err
 	}
 
-	return uri.String(), nil
+	if r.TLS != nil {
+		url.Scheme = "https"
+	}
+
+	return url.String(), nil
 }
 
 // Messages returns all of the messages set by the request handler to be included in

--- a/rest/context.go
+++ b/rest/context.go
@@ -72,7 +72,8 @@ type RequestContext interface {
 	// string is returned with the error set.
 	NextURL() (string, error)
 
-	BuildURL(string, string) (string, error)
+	// BuildURL builds the URL for the given route name and resource ID.
+	BuildURL(routeName, resourceID string) (string, error)
 
 	// ResponseFormat returns the response format for the request, defaulting to "json" if
 	// one is not specified using the "format" query parameter.

--- a/rest/context.go
+++ b/rest/context.go
@@ -139,7 +139,7 @@ type gorillaRequestContext struct {
 
 // NewContext returns a RequestContext populated with parameters from the request path and
 // query string.
-func NewContext(parent context.Context, req *http.Request, router *mux.Router) RequestContext {
+func NewContext(parent context.Context, req *http.Request) RequestContext {
 	if parent == nil {
 		parent = context.Background()
 	}
@@ -166,7 +166,13 @@ func NewContext(parent context.Context, req *http.Request, router *mux.Router) R
 	// parameters with the same name as query string values. Figure out a
 	// better way to handle this.
 
-	return &gorillaRequestContext{parent, req, router, []string{}}
+	return &gorillaRequestContext{parent, req, nil, []string{}}
+}
+
+func NewContextWithRouter(parent context.Context, req *http.Request, router *mux.Router) RequestContext {
+	context := NewContext(parent, req)
+	context.(*gorillaRequestContext).router = router
+	return context
 }
 
 // WithValue returns a new RequestContext with the provided key-value pair and this context

--- a/rest/context.go
+++ b/rest/context.go
@@ -18,7 +18,6 @@ package rest
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -332,7 +331,8 @@ func (ctx *gorillaRequestContext) NextURL() (string, error) {
 func (ctx *gorillaRequestContext) BuildURL(routeName, resourceID string) (string, error) {
 	r, ok := ctx.Request()
 	if !ok {
-		return "", fmt.Errorf("Unable to build next url: no request")
+		return "", fmt.Errorf("Unable to build URL for route name %q with resource ID %q: No request available.",
+			routeName, resourceID)
 	}
 
 	scheme := "http"
@@ -348,9 +348,10 @@ func (ctx *gorillaRequestContext) BuildURL(routeName, resourceID string) (string
 		URL("version", ctx.Version(),
 		"resource_id", resourceID)
 	if err != nil {
-		log.Println(err)
+		return "", err
 	}
-	return fmt.Sprintf("%v", uri), nil
+
+	return uri.String(), nil
 }
 
 // Messages returns all of the messages set by the request handler to be included in

--- a/rest/context.go
+++ b/rest/context.go
@@ -72,21 +72,18 @@ type RequestContext interface {
 	// string is returned with the error set.
 	NextURL() (string, error)
 
-	// BuildURL builds a full URL for the given resource name & method name with the
-	// key/value pairs for the route variables.
+	// BuildURL builds a full URL for a resource name & method.
 	//
 	// resourceName should have the same value as the handler's ResourceName method.
 	//
-	// methodName should be the Handle* constant that corresponds with the resource
+	// method is the HandleMethod constant that corresponds with the resource
 	// method for which to build the URL. E.g. HandleCreate with build a URL that
 	// corresponds with the CreateResource method.
 	//
-	// pairs should be key/value pairs for any URL variables, passed on to
-	// gorilla's Route.URL method.
+	// All URL variables should be named in the vars map.
 	BuildURL(resourceName string, method HandleMethod, vars RouteVars) (string, error)
 
-	// BuildPath builds a URL path for the given resource name & method name with the
-	// key/value pairs for the route variables.
+	// BuildURL builds a full URL for a resource name & method.
 	//
 	// See BuildURL for more details.
 	BuildPath(resourceName string, method HandleMethod, vars RouteVars) (string, error)
@@ -389,23 +386,20 @@ func (ctx *gorillaRequestContext) buildURL(fullPath bool, resourceName string,
 	return url.String(), nil
 }
 
-// BuildURL builds a full URL for the given resource name & method name with the
-// key/value pairs for the route variables.
+// BuildURL builds a full URL for a resource name & method.
 //
 // resourceName should have the same value as the handler's ResourceName method.
 //
-// methodName should be the Handle* constant that corresponds with the resource
+// method is the HandleMethod constant that corresponds with the resource
 // method for which to build the URL. E.g. HandleCreate with build a URL that
 // corresponds with the CreateResource method.
 //
-// pairs should be key/value pairs for any URL variables, passed on to
-// gorilla's Route.URL method.
+// All URL variables should be named in the vars map.
 func (ctx *gorillaRequestContext) BuildURL(resourceName string, method HandleMethod, vars RouteVars) (string, error) {
 	return ctx.buildURL(true, resourceName, method, vars)
 }
 
-// BuildPath builds a URL path for the given resource name & method name with the
-// key/value pairs for the route variables.
+// BuildURL builds a full URL for a resource name & method.
 //
 // See BuildURL for more details.
 func (ctx *gorillaRequestContext) BuildPath(resourceName string, method HandleMethod, vars RouteVars) (string, error) {

--- a/rest/context.go
+++ b/rest/context.go
@@ -83,13 +83,13 @@ type RequestContext interface {
 	//
 	// pairs should be key/value pairs for any URL variables, passed on to
 	// gorilla's Route.URL method.
-	BuildURL(resourceName string, methodName string, pairs ...string) (string, error)
+	BuildURL(resourceName string, method HandleMethod, pairs ...string) (string, error)
 
 	// BuildPath builds a URL path for the given resource name & method name with the
 	// key/value pairs for the route variables.
 	//
 	// See BuildURL for more details.
-	BuildPath(resourceName string, methodName string, pairs ...string) (string, error)
+	BuildPath(resourceName string, method HandleMethod, pairs ...string) (string, error)
 
 	// ResponseFormat returns the response format for the request, defaulting to "json" if
 	// one is not specified using the "format" query parameter.
@@ -352,14 +352,14 @@ func (ctx *gorillaRequestContext) NextURL() (string, error) {
 }
 
 func (ctx *gorillaRequestContext) buildURL(fullPath bool, resourceName string,
-	methodName string, pairs ...string) (string, error) {
+	method HandleMethod, pairs ...string) (string, error) {
 	r, ok := ctx.Request()
 	if !ok {
-		return "", fmt.Errorf("unable to build URL for resource name %q: no request available.",
+		return "", fmt.Errorf("unable to build URL for resource name %q: no request available",
 			resourceName)
 	}
 
-	routeName := resourceName + ":" + methodName
+	routeName := resourceName + ":" + string(method)
 	route := ctx.router.Get(routeName).Host(r.Host)
 
 	var builder func(pairs ...string) (*url.URL, error)
@@ -393,16 +393,16 @@ func (ctx *gorillaRequestContext) buildURL(fullPath bool, resourceName string,
 //
 // pairs should be key/value pairs for any URL variables, passed on to
 // gorilla's Route.URL method.
-func (ctx *gorillaRequestContext) BuildURL(resourceName string, methodName string, pairs ...string) (string, error) {
-	return ctx.buildURL(true, resourceName, methodName, pairs...)
+func (ctx *gorillaRequestContext) BuildURL(resourceName string, method HandleMethod, pairs ...string) (string, error) {
+	return ctx.buildURL(true, resourceName, method, pairs...)
 }
 
 // BuildPath builds a URL path for the given resource name & method name with the
 // key/value pairs for the route variables.
 //
 // See BuildURL for more details.
-func (ctx *gorillaRequestContext) BuildPath(resourceName string, methodName string, pairs ...string) (string, error) {
-	return ctx.buildURL(false, resourceName, methodName, pairs...)
+func (ctx *gorillaRequestContext) BuildPath(resourceName string, method HandleMethod, pairs ...string) (string, error) {
+	return ctx.buildURL(false, resourceName, method, pairs...)
 }
 
 // Messages returns all of the messages set by the request handler to be included in

--- a/rest/context.go
+++ b/rest/context.go
@@ -348,6 +348,11 @@ func (ctx *gorillaRequestContext) NextURL() (string, error) {
 	return u.String(), nil
 }
 
+// RouteVars is a map of URL route variables to values.
+//
+//     vars = RouteVars{"category": "widgets", "resource_id": "42"}
+//
+// Variables are defined in CreateURI and the other URI methods.
 type RouteVars map[string]string
 
 func (ctx *gorillaRequestContext) buildURL(fullPath bool, resourceName string,

--- a/rest/context_test.go
+++ b/rest/context_test.go
@@ -27,9 +27,13 @@ import (
 )
 
 // Test Handlers
-type TestResourceHandler struct{ BaseResourceHandler }
+type TestResourceHandler struct {
+	BaseResourceHandler
+}
 
-func (t TestResourceHandler) ResourceName() string { return "widgets" }
+func (t TestResourceHandler) ResourceName() string {
+	return "widgets"
+}
 
 func (t TestResourceHandler) CreateResource(r RequestContext, data Payload,
 	version string) (Resource, error) {
@@ -45,9 +49,13 @@ func (t TestResourceHandler) ReadResource(r RequestContext, id string,
 	return resource, nil
 }
 
-type ComplexTestResourceHandler struct{ BaseResourceHandler }
+type ComplexTestResourceHandler struct {
+	BaseResourceHandler
+}
 
-func (t ComplexTestResourceHandler) ResourceName() string { return "resources" }
+func (t ComplexTestResourceHandler) ResourceName() string {
+	return "resources"
+}
 
 func (t ComplexTestResourceHandler) CreateURI() string {
 	return "/api/v{version:[^/]+}/{company}/{category}/resources"

--- a/rest/context_test.go
+++ b/rest/context_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +29,7 @@ import (
 func TestLimitDefault(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req)
+	ctx := NewContext(nil, req, mux.NewRouter())
 	assert.Equal(100, ctx.Limit())
 }
 
@@ -36,7 +37,7 @@ func TestLimitDefault(t *testing.T) {
 func TestLimitBadValue(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req)
+	ctx := NewContext(nil, req, mux.NewRouter())
 	ctx = ctx.WithValue(limitKey, "blah")
 	assert.Equal(100, ctx.Limit())
 }
@@ -45,7 +46,7 @@ func TestLimitBadValue(t *testing.T) {
 func TestLimit(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req)
+	ctx := NewContext(nil, req, mux.NewRouter())
 	ctx = ctx.WithValue(limitKey, "5")
 	assert.Equal(5, ctx.Limit())
 }
@@ -54,7 +55,7 @@ func TestLimit(t *testing.T) {
 func TestMessagesNoError(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req)
+	ctx := NewContext(nil, req, mux.NewRouter())
 	message := "foo"
 
 	assert.Equal(0, len(ctx.Messages()))
@@ -71,7 +72,7 @@ func TestMessagesNoError(t *testing.T) {
 func TestMessagesWithError(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req)
+	ctx := NewContext(nil, req, mux.NewRouter())
 	message := "foo"
 	errMessage := "blah"
 	err := fmt.Errorf(errMessage)
@@ -93,7 +94,7 @@ func TestMessagesWithError(t *testing.T) {
 func TestHeader(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req)
+	ctx := NewContext(nil, req, mux.NewRouter())
 
 	assert.Equal(req.Header, ctx.Header())
 }

--- a/rest/context_test.go
+++ b/rest/context_test.go
@@ -117,17 +117,32 @@ func TestBuildURL(t *testing.T) {
 		Schemes("http", "https").
 		Name("test_get_route")
 
+	router.
+		Path("/api/v{version}/{company}/{category}/widgets").
+		Methods("GET").
+		Schemes("http", "https").
+		Name("test_complex_get_route")
+
 	req, _ := http.NewRequest("GET", "https://example.com/api/v1/widgets", nil)
 	gContext.Set(req, "version", "1")
 
 	ctx := NewContextWithRouter(nil, req, router)
 
-	url, _ := ctx.BuildURL("test_post_route", "111")
+	url, _ := ctx.BuildURL("test_post_route", "resource_id", "111")
 	assert.Equal(url, "http://example.com/api/v1/widgets/111")
+
+	url, _ = ctx.BuildPath("test_post_route", "resource_id", "111")
+	assert.Equal(url, "/api/v1/widgets/111")
 
 	// Secure request should produce https URL
 	req.TLS = &tls.ConnectionState{}
-	url, _ = ctx.BuildURL("test_post_route", "222")
+	url, _ = ctx.BuildURL("test_post_route", "resource_id", "222")
 	assert.Equal(url, "https://example.com/api/v1/widgets/222")
+
+	url, _ = ctx.BuildURL(
+		"test_complex_get_route",
+		"company", "acme",
+		"category", "anvils")
+	assert.Equal(url, "https://example.com/api/v1/acme/anvils/widgets")
 
 }

--- a/rest/context_test.go
+++ b/rest/context_test.go
@@ -167,8 +167,10 @@ func TestBuildURL(t *testing.T) {
 	url, _ = ctx.BuildURL("widgets", HandleRead, RouteVars{"resource_id": "222"})
 	assert.Equal(url, "https://example.com/api/v1/widgets/222")
 
+	// Make sure this works with another version number
+	gContext.Set(req, "version", "2")
 	url, _ = ctx.BuildURL("resources", HandleCreate, RouteVars{
 		"company":  "acme",
 		"category": "anvils"})
-	assert.Equal(url, "https://example.com/api/v1/acme/anvils/resources")
+	assert.Equal(url, "https://example.com/api/v2/acme/anvils/resources")
 }

--- a/rest/context_test.go
+++ b/rest/context_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,7 +28,7 @@ import (
 func TestLimitDefault(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req, mux.NewRouter())
+	ctx := NewContext(nil, req)
 	assert.Equal(100, ctx.Limit())
 }
 
@@ -37,7 +36,7 @@ func TestLimitDefault(t *testing.T) {
 func TestLimitBadValue(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req, mux.NewRouter())
+	ctx := NewContext(nil, req)
 	ctx = ctx.WithValue(limitKey, "blah")
 	assert.Equal(100, ctx.Limit())
 }
@@ -46,7 +45,7 @@ func TestLimitBadValue(t *testing.T) {
 func TestLimit(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req, mux.NewRouter())
+	ctx := NewContext(nil, req)
 	ctx = ctx.WithValue(limitKey, "5")
 	assert.Equal(5, ctx.Limit())
 }
@@ -55,7 +54,7 @@ func TestLimit(t *testing.T) {
 func TestMessagesNoError(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req, mux.NewRouter())
+	ctx := NewContext(nil, req)
 	message := "foo"
 
 	assert.Equal(0, len(ctx.Messages()))
@@ -72,7 +71,7 @@ func TestMessagesNoError(t *testing.T) {
 func TestMessagesWithError(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req, mux.NewRouter())
+	ctx := NewContext(nil, req)
 	message := "foo"
 	errMessage := "blah"
 	err := fmt.Errorf(errMessage)
@@ -94,7 +93,7 @@ func TestMessagesWithError(t *testing.T) {
 func TestHeader(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	ctx := NewContext(nil, req, mux.NewRouter())
+	ctx := NewContext(nil, req)
 
 	assert.Equal(req.Header, ctx.Header())
 }

--- a/rest/context_test.go
+++ b/rest/context_test.go
@@ -153,22 +153,22 @@ func TestBuildURL(t *testing.T) {
 
 	ctx := NewContextWithRouter(nil, req, api.(*muxAPI).router)
 
-	url, _ := ctx.BuildURL("widgets", HandleCreate)
+	url, _ := ctx.BuildURL("widgets", HandleCreate, nil)
 	assert.Equal(url, "http://example.com/api/v1/widgets")
 
-	url, _ = ctx.BuildURL("widgets", HandleRead, "resource_id", "111")
+	url, _ = ctx.BuildURL("widgets", HandleRead, RouteVars{"resource_id": "111"})
 	assert.Equal(url, "http://example.com/api/v1/widgets/111")
 
-	url, _ = ctx.BuildPath("widgets", HandleRead, "resource_id", "111")
+	url, _ = ctx.BuildPath("widgets", HandleRead, RouteVars{"resource_id": "111"})
 	assert.Equal(url, "/api/v1/widgets/111")
 
 	// Secure request should produce https URL
 	req.TLS = &tls.ConnectionState{}
-	url, _ = ctx.BuildURL("widgets", HandleRead, "resource_id", "222")
+	url, _ = ctx.BuildURL("widgets", HandleRead, RouteVars{"resource_id": "222"})
 	assert.Equal(url, "https://example.com/api/v1/widgets/222")
 
-	url, _ = ctx.BuildURL("resources", HandleCreate,
-		"company", "acme",
-		"category", "anvils")
+	url, _ = ctx.BuildURL("resources", HandleCreate, RouteVars{
+		"company":  "acme",
+		"category": "anvils"})
 	assert.Equal(url, "https://example.com/api/v1/acme/anvils/resources")
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -131,7 +131,7 @@ type requestHandler struct {
 // The serialization mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleCreate(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r)
+		ctx := NewContext(nil, r, h.Router())
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -172,7 +172,7 @@ func (h requestHandler) handleCreate(handler ResourceHandler) http.Handler {
 // serialization mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleReadList(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r)
+		ctx := NewContext(nil, r, h.Router())
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -200,7 +200,7 @@ func (h requestHandler) handleReadList(handler ResourceHandler) http.Handler {
 // mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleRead(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r)
+		ctx := NewContext(nil, r, h.Router())
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -223,7 +223,7 @@ func (h requestHandler) handleRead(handler ResourceHandler) http.Handler {
 // parameter.
 func (h requestHandler) handleUpdateList(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r)
+		ctx := NewContext(nil, r, h.Router())
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -272,7 +272,7 @@ func (h requestHandler) handleUpdateList(handler ResourceHandler) http.Handler {
 // parameter.
 func (h requestHandler) handleUpdate(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r)
+		ctx := NewContext(nil, r, h.Router())
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -307,7 +307,7 @@ func (h requestHandler) handleUpdate(handler ResourceHandler) http.Handler {
 // mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleDelete(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r)
+		ctx := NewContext(nil, r, h.Router())
 		version := ctx.Version()
 		rules := handler.Rules()
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -134,7 +134,7 @@ type requestHandler struct {
 // The serialization mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleCreate(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.router)
+		ctx := NewContextWithRouter(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -175,7 +175,7 @@ func (h requestHandler) handleCreate(handler ResourceHandler) http.Handler {
 // serialization mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleReadList(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.router)
+		ctx := NewContextWithRouter(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -203,7 +203,7 @@ func (h requestHandler) handleReadList(handler ResourceHandler) http.Handler {
 // mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleRead(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.router)
+		ctx := NewContextWithRouter(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -226,7 +226,7 @@ func (h requestHandler) handleRead(handler ResourceHandler) http.Handler {
 // parameter.
 func (h requestHandler) handleUpdateList(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.router)
+		ctx := NewContextWithRouter(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -275,7 +275,7 @@ func (h requestHandler) handleUpdateList(handler ResourceHandler) http.Handler {
 // parameter.
 func (h requestHandler) handleUpdate(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.router)
+		ctx := NewContextWithRouter(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -310,7 +310,7 @@ func (h requestHandler) handleUpdate(handler ResourceHandler) http.Handler {
 // mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleDelete(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.router)
+		ctx := NewContextWithRouter(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -23,6 +23,8 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+
+	"github.com/gorilla/mux"
 )
 
 // Resource represents a domain model.
@@ -124,6 +126,7 @@ type ResourceHandler interface {
 // requestHandler constructs http.HandlerFuncs responsible for handling HTTP requests.
 type requestHandler struct {
 	API
+	router *mux.Router
 }
 
 // handleCreate returns a HandlerFunc which will deserialize the request payload, pass
@@ -131,7 +134,7 @@ type requestHandler struct {
 // The serialization mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleCreate(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.Router())
+		ctx := NewContext(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -172,7 +175,7 @@ func (h requestHandler) handleCreate(handler ResourceHandler) http.Handler {
 // serialization mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleReadList(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.Router())
+		ctx := NewContext(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -200,7 +203,7 @@ func (h requestHandler) handleReadList(handler ResourceHandler) http.Handler {
 // mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleRead(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.Router())
+		ctx := NewContext(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -223,7 +226,7 @@ func (h requestHandler) handleRead(handler ResourceHandler) http.Handler {
 // parameter.
 func (h requestHandler) handleUpdateList(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.Router())
+		ctx := NewContext(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -272,7 +275,7 @@ func (h requestHandler) handleUpdateList(handler ResourceHandler) http.Handler {
 // parameter.
 func (h requestHandler) handleUpdate(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.Router())
+		ctx := NewContext(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 
@@ -307,7 +310,7 @@ func (h requestHandler) handleUpdate(handler ResourceHandler) http.Handler {
 // mechanism used is specified by the "format" query parameter.
 func (h requestHandler) handleDelete(handler ResourceHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(nil, r, h.Router())
+		ctx := NewContext(nil, r, h.router)
 		version := ctx.Version()
 		rules := handler.Rules()
 


### PR DESCRIPTION
Problem
=======

It would be useful to be able to generate a URL for a given endpoint with a set of parameters -- for example, in a POST endpoint, you might want to provide the user with the GET endpoint where they can retrieve the resource they just created.
 
See webapp2's [uri_for()](https://webapp-improved.appspot.com/guide/routing.html#guide-routing-building-uris) among others for an example of this.

Solution
======

Added the router to the `gorillaRequestContext` struct, and `BuildURL()` & `BuildPath()` methods to the `RequestContext` interface, so the user can get a full URL or path for an endpoint.

Code Review
===========
@tylertreat 
@alexandercampbell-wf 

FYI: 
@trentonsmith-wf 