### PR TITLE
Fixed Issue x-www-form-urlencoded

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rest
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -126,13 +125,6 @@ type ResourceHandler interface {
 type requestHandler struct {
 	API
 }
-
-type myReader struct {
-	*bytes.Buffer
-}
-
-// So that it implements the io.ReadCloser interface
-func (m myReader) Close() error { return nil }
 
 // handleCreate returns a HandlerFunc which will deserialize the request payload, pass
 // it to the provided create function, and then serialize and dispatch the response.


### PR DESCRIPTION
This fixes a bug with the restful service attempting to unmarshal a x-www-form-urlencoded request like it is JSON in POST/PUT requests. This fix simply prevents umarshal from tampering with the request body and returning an error so it can be encoded further down the line using something like [this](http://www.gorillatoolkit.org/pkg/schema).

I was considering doing the decoding using gorilla/schema to the payload in this PR like I'm doing in my program, but I don't know what the policy on external libraries is.   