### PR TITLE
Fix for BuildURL handler overwriting

### DIFF
--- a/rest/context.go
+++ b/rest/context.go
@@ -364,7 +364,7 @@ func (ctx *gorillaRequestContext) buildURL(fullPath bool, resourceName string,
 	}
 
 	routeName := resourceName + ":" + string(method)
-	route := ctx.router.Get(routeName).Host(r.Host)
+	route := ctx.router.Get(routeName)
 
 	var builder func(pairs ...string) (*url.URL, error)
 	if fullPath {
@@ -383,9 +383,11 @@ func (ctx *gorillaRequestContext) buildURL(fullPath bool, resourceName string,
 	if err != nil {
 		return "", err
 	}
+	url.Host = r.Host
 
+	url.Scheme = "http"
 	if r.TLS != nil {
-		url.Scheme = "https"
+		url.Scheme += "s"
 	}
 
 	return url.String(), nil

--- a/rest/context.go
+++ b/rest/context.go
@@ -366,20 +366,13 @@ func (ctx *gorillaRequestContext) buildURL(fullPath bool, resourceName string,
 	routeName := resourceName + ":" + string(method)
 	route := ctx.router.Get(routeName)
 
-	var builder func(pairs ...string) (*url.URL, error)
-	if fullPath {
-		builder = route.URL
-	} else {
-		builder = route.URLPath
-	}
-
 	// Transform RouteVars map to list of key, val pairs for Gorilla's API
 	pairs := make([]string, (len(vars)*2)+2)
 	for key, val := range vars {
 		pairs = append(pairs, key, val)
 	}
 	pairs = append(pairs, "version", ctx.Version())
-	url, err := builder(pairs...)
+	url, err := route.URL(pairs...)
 	if err != nil {
 		return "", err
 	}
@@ -390,7 +383,13 @@ func (ctx *gorillaRequestContext) buildURL(fullPath bool, resourceName string,
 		url.Scheme += "s"
 	}
 
-	return url.String(), nil
+	urlStr := ""
+	if fullPath {
+		urlStr = url.String()
+	} else {
+		urlStr = url.Path
+	}
+	return urlStr, nil
 }
 
 // BuildURL builds a full URL for a resource name & method.


### PR DESCRIPTION
If BuildURL was used, the handler that it creates a URL for(HandleMethod) had its host changed to the request's host. This fixes that issue.

@aaronkavlie-wf @tylertreat-wf @alexandercampbell-wf @stevenosborne-wf 