### PR TITLE
BuildURL returns *url.URL instead of string / Remove BuildPath

### DIFF
--- a/rest/context.go
+++ b/rest/context.go
@@ -350,7 +350,16 @@ func (ctx *gorillaRequestContext) NextURL() (string, error) {
 // Variables are defined in CreateURI and the other URI methods.
 type RouteVars map[string]string
 
-func (ctx *gorillaRequestContext) buildURL(fullPath bool, resourceName string,
+// BuildURL builds a full URL for a resource name & method.
+//
+// resourceName should have the same value as the handler's ResourceName method.
+//
+// method is the HandleMethod constant that corresponds with the resource
+// method for which to build the URL. E.g. HandleCreate with build a URL that
+// corresponds with the CreateResource method.
+//
+// All URL variables should be named in the vars map.
+func (ctx *gorillaRequestContext) BuildURL(resourceName string,
 	method HandleMethod, vars RouteVars) (*url.URL, error) {
 	r, ok := ctx.Request()
 	if !ok {
@@ -379,19 +388,6 @@ func (ctx *gorillaRequestContext) buildURL(fullPath bool, resourceName string,
 	}
 
 	return url, nil
-}
-
-// BuildURL builds a full URL for a resource name & method.
-//
-// resourceName should have the same value as the handler's ResourceName method.
-//
-// method is the HandleMethod constant that corresponds with the resource
-// method for which to build the URL. E.g. HandleCreate with build a URL that
-// corresponds with the CreateResource method.
-//
-// All URL variables should be named in the vars map.
-func (ctx *gorillaRequestContext) BuildURL(resourceName string, method HandleMethod, vars RouteVars) (*url.URL, error) {
-	return ctx.buildURL(true, resourceName, method, vars)
 }
 
 // Messages returns all of the messages set by the request handler to be included in

--- a/rest/context_test.go
+++ b/rest/context_test.go
@@ -154,23 +154,23 @@ func TestBuildURL(t *testing.T) {
 	ctx := NewContextWithRouter(nil, req, api.(*muxAPI).router)
 
 	url, _ := ctx.BuildURL("widgets", HandleCreate, nil)
-	assert.Equal(url, "http://example.com/api/v1/widgets")
+	assert.Equal(url.String(), "http://example.com/api/v1/widgets")
 
 	url, _ = ctx.BuildURL("widgets", HandleRead, RouteVars{"resource_id": "111"})
-	assert.Equal(url, "http://example.com/api/v1/widgets/111")
+	assert.Equal(url.String(), "http://example.com/api/v1/widgets/111")
 
-	url, _ = ctx.BuildPath("widgets", HandleRead, RouteVars{"resource_id": "111"})
-	assert.Equal(url, "/api/v1/widgets/111")
+	url, _ = ctx.BuildURL("widgets", HandleRead, RouteVars{"resource_id": "111"})
+	assert.Equal(url.Path, "/api/v1/widgets/111")
 
 	// Secure request should produce https URL
 	req.TLS = &tls.ConnectionState{}
 	url, _ = ctx.BuildURL("widgets", HandleRead, RouteVars{"resource_id": "222"})
-	assert.Equal(url, "https://example.com/api/v1/widgets/222")
+	assert.Equal(url.String(), "https://example.com/api/v1/widgets/222")
 
 	// Make sure this works with another version number
 	gContext.Set(req, "version", "2")
 	url, _ = ctx.BuildURL("resources", HandleCreate, RouteVars{
 		"company":  "acme",
 		"category": "anvils"})
-	assert.Equal(url, "https://example.com/api/v2/acme/anvils/resources")
+	assert.Equal(url.String(), "https://example.com/api/v2/acme/anvils/resources")
 }


### PR DESCRIPTION
It makes more sense to return the url.URL struct, as it gives many more options for usage. This led to removing BuildPath from the gorillaRequestContext, as it is redundant.

@tylertreat @stevenosborne-wf @aaronkavlie-wf @alexandercampbell-wf 