### PR TITLE
Fix panic in applyNestedInboundRules

### DIFF
--- a/rest/rule.go
+++ b/rest/rule.go
@@ -334,9 +334,11 @@ func applyNestedInboundRules(
 		s := reflect.ValueOf(value)
 		nestedValues := make([]interface{}, s.Len())
 		for i := 0; i < s.Len(); i++ {
-			var payload map[string]interface{}
-			payload, err := applyInboundRules(
-				s.Index(i).Interface().(map[string]interface{}), rules, version)
+			payloadIFace, err := coerceType(s.Index(i).Interface(), Map)
+			if err != nil {
+				return nil, err
+			}
+			payload, err := applyInboundRules(payloadIFace.(map[string]interface{}), rules, version)
 			if err != nil {
 				return nil, err
 			}
@@ -344,9 +346,11 @@ func applyNestedInboundRules(
 		}
 		fieldValue = nestedValues
 	} else {
-		var payload map[string]interface{}
-		payload, err := applyInboundRules(
-			value.(map[string]interface{}), rules, version)
+		payloadIFace, err := coerceType(value, Map)
+		if err != nil {
+			return nil, err
+		}
+		payload, err := applyInboundRules(payloadIFace.(map[string]interface{}), rules, version)
 		if err != nil {
 			return nil, err
 		}

--- a/rest/rule.go
+++ b/rest/rule.go
@@ -338,7 +338,8 @@ func applyNestedInboundRules(
 			if err != nil {
 				return nil, err
 			}
-			payload, err := applyInboundRules(payloadIFace.(map[string]interface{}), rules, version)
+			var payload map[string]interface{}
+			payload, err = applyInboundRules(payloadIFace.(map[string]interface{}), rules, version)
 			if err != nil {
 				return nil, err
 			}
@@ -350,7 +351,8 @@ func applyNestedInboundRules(
 		if err != nil {
 			return nil, err
 		}
-		payload, err := applyInboundRules(payloadIFace.(map[string]interface{}), rules, version)
+		var payload map[string]interface{}
+		payload, err = applyInboundRules(payloadIFace.(map[string]interface{}), rules, version)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The coercion from interface to map[string]interface panicked if a payload with a slice of something besides a map is sent.
```
{["foo", bar"]}
```

I'm not sure what the intended behavior is, but this fixes the panic.

@tylertreat @stevenosborne-wf @aaronkavlie-wf @alexandercampbell-wf 