### PR TITLE
Allow generation of documentation for resources that have no output field

### DIFF
--- a/rest/doc.go
+++ b/rest/doc.go
@@ -221,8 +221,8 @@ func (d *defaultContextGenerator) generate(handler ResourceHandler, version stri
 	inputFields := getInputFields(handler.Rules().ForVersion(version))
 	outputFields := getOutputFields(handler.Rules().ForVersion(version))
 
-	if len(outputFields) == 0 {
-		// Handler has no output fields for this version.
+	if len(inputFields) == 0 && len(outputFields) == 0 {
+		// Handler has no fields for this version.
 		return nil, nil
 	}
 

--- a/rest/doc_test.go
+++ b/rest/doc_test.go
@@ -451,7 +451,7 @@ func TestGenerateDocsHappyPath(t *testing.T) {
 	assert.Nil(docGenerator.generateDocs(api), "Return value should be nil")
 }
 
-// Ensures that generate returns nil context and nil error when there are no output fields for a
+// Ensures that generate returns nil context and nil error when there are no fields for a
 // version.
 func TestGenerateNoOutput(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
@tylertreat @stevenosborne-wf 