### PR TITLE
Allow nested rules for primitives in a slice

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -31,6 +31,10 @@ type TestResource struct {
 	Foo string `json:"foo"`
 }
 
+type TestResourceSlice struct {
+	Foo []string `json:"foo"`
+}
+
 type MockResourceHandler struct {
 	mock.Mock
 	BaseResourceHandler

--- a/rest/rule.go
+++ b/rest/rule.go
@@ -341,7 +341,7 @@ func applyNestedInboundRules(
 		for i := 0; i < s.Len(); i++ {
 			// Check to see if the nested type is a slice or map.
 			// If not, it is a primitive which should be coerced to its rule type.
-			if iType := reflect.TypeOf(s.Index(i).Interface()).Kind(); iType != reflect.Map && iType != reflect.Slice && iType != reflect.Struct {
+			if iType := reflect.TypeOf(s.Index(i).Interface()).Kind(); iType != reflect.Map && iType != reflect.Slice {
 				payloadIFace, err := coerceType(s.Index(i).Interface(), rules.Contents()[0].Type)
 				if err != nil {
 					return nil, err

--- a/rest/rule.go
+++ b/rest/rule.go
@@ -108,10 +108,11 @@ func (r *rules) Validate() error {
 
 		// Validate nested Rules.
 		if rule.Rules != nil {
-			// If a rule is on a slice, check for to see what the underlying type is.
+			// If a rule is on a slice, check to see what the underlying type is.
 			// If it is primitive, there is nothing to validate.
 			if typeToKind[rule.Type] == reflect.Slice {
-				if nestedType := typeToKind[rule.Rules.Contents()[0].Type]; nestedType == reflect.Struct || nestedType == reflect.Map {
+				nestedType := typeToKind[rule.Rules.Contents()[0].Type]
+				if nestedType == reflect.Struct || nestedType == reflect.Map {
 					if err := rule.Rules.Validate(); err != nil {
 						return err
 					}

--- a/rest/rule.go
+++ b/rest/rule.go
@@ -110,10 +110,11 @@ func (r *rules) Validate() error {
 		if rule.Rules != nil {
 			// If a rule is on a slice, check for to see what the underlying type is.
 			// If it is primitive, there is nothing to validate.
-			if nestedType := typeToKind[rule.Rules.Contents()[0].Type]; typeToKind[rule.Type] == reflect.Slice &&
-				nestedType == reflect.Struct || nestedType == reflect.Map {
-				if err := rule.Rules.Validate(); err != nil {
-					return err
+			if typeToKind[rule.Type] == reflect.Slice {
+				if nestedType := typeToKind[rule.Rules.Contents()[0].Type]; nestedType == reflect.Struct || nestedType == reflect.Map {
+					if err := rule.Rules.Validate(); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/rest/rule.go
+++ b/rest/rule.go
@@ -343,8 +343,12 @@ func applyNestedInboundRules(
 		for i := 0; i < s.Len(); i++ {
 			// Check to see if the nested type is a slice or map.
 			// If not, it should be coerced to its rule type.
-			if iType := reflect.TypeOf(s.Index(i).Interface()).Kind(); iType != reflect.Map && iType != reflect.Slice {
-				payloadIFace, err := coerceType(s.Index(i).Interface(), rules.Contents()[0].Type)
+			iKind := reflect.TypeOf(s.Index(i).Interface()).Kind()
+			ruleType := rules.Contents()[0].Type
+			if ruleKind := typeToKind[ruleType]; iKind == reflect.Slice && ruleKind != reflect.Slice {
+				return nil, fmt.Errorf("Value does not match rule type, expecting: %v, got: %v", ruleKind, iKind)
+			} else if iKind != reflect.Map && iKind != reflect.Slice {
+				payloadIFace, err := coerceType(s.Index(i).Interface(), ruleType)
 				if err != nil {
 					return nil, err
 				}

--- a/rest/rule.go
+++ b/rest/rule.go
@@ -111,7 +111,7 @@ func (r *rules) Validate() error {
 			// If a rule is on a slice, check for to see what the underlying type is.
 			// If it is primitive, there is nothing to validate.
 			if nestedType := typeToKind[rule.Rules.Contents()[0].Type]; typeToKind[rule.Type] == reflect.Slice &&
-				nestedType == reflect.Struct || nestedType == reflect.Map && reflect.Struct == reflect.Slice {
+				nestedType == reflect.Struct || nestedType == reflect.Map {
 				if err := rule.Rules.Validate(); err != nil {
 					return err
 				}
@@ -340,7 +340,7 @@ func applyNestedInboundRules(
 		nestedValues := make([]interface{}, s.Len())
 		for i := 0; i < s.Len(); i++ {
 			// Check to see if the nested type is a slice or map.
-			// If not, it is a primitive which should be coerced to its rule type.
+			// If not, it should be coerced to its rule type.
 			if iType := reflect.TypeOf(s.Index(i).Interface()).Kind(); iType != reflect.Map && iType != reflect.Slice {
 				payloadIFace, err := coerceType(s.Index(i).Interface(), rules.Contents()[0].Type)
 				if err != nil {

--- a/rest/rule_test.go
+++ b/rest/rule_test.go
@@ -987,8 +987,8 @@ func TestApplyInboundRulesNestedRulesSlice(t *testing.T) {
 	assert.Nil(err, "Error should be nil")
 }
 
-// Ensures that nested inbound Rules are correctly applied to slices.
-func TestApplyInboundRulesNestedRulesSliceOfPrimitive(t *testing.T) {
+// Ensures that nested inbound Rules are correctly applied to slices of primitives.
+func TestApplyNestedInboundRulesSliceOfPrimitive(t *testing.T) {
 	assert := assert.New(t)
 	payload := []string{"foo", "bar"}
 	rules := NewRules((*string)(nil),
@@ -999,7 +999,7 @@ func TestApplyInboundRulesNestedRulesSliceOfPrimitive(t *testing.T) {
 
 	actual, err := applyNestedInboundRules(payload, rules, "1")
 
-	assert.Equal([]interface{}{"foo", "bar"}, actual, fmt.Sprintf("Incorrect return value %s", payload))
+	assert.Equal([]interface{}{"foo", "bar"}, actual, "Incorrect return value")
 
 	assert.Nil(err, "Error should be nil")
 }

--- a/rest/rule_test.go
+++ b/rest/rule_test.go
@@ -987,6 +987,23 @@ func TestApplyInboundRulesNestedRulesSlice(t *testing.T) {
 	assert.Nil(err, "Error should be nil")
 }
 
+// Ensures that nested inbound Rules are correctly applied to slices.
+func TestApplyInboundRulesNestedRulesSliceOfPrimitive(t *testing.T) {
+	assert := assert.New(t)
+	payload := []string{"foo", "bar"}
+	rules := NewRules((*string)(nil),
+		&Rule{
+			Type: String,
+		},
+	)
+
+	actual, err := applyNestedInboundRules(payload, rules, "1")
+
+	assert.Equal([]interface{}{"foo", "bar"}, actual, fmt.Sprintf("Incorrect return value %s", payload))
+
+	assert.Nil(err, "Error should be nil")
+}
+
 // Ensures that nested inbound Rules are not applied if they do not apply to the version.
 func TestApplyInboundRulesNestedRulesDifferentVersion(t *testing.T) {
 	assert := assert.New(t)

--- a/rest/rule_test.go
+++ b/rest/rule_test.go
@@ -993,10 +993,10 @@ func TestApplyInboundRulesNestedRulesUnableToCoerceToPrimitive(t *testing.T) {
 	payload := Payload{"foo": []interface{}{"bar", []interface{}{"baz"}}}
 	rules := NewRules((*TestResourceSlice)(nil),
 		&Rule{
-			Field: "Foo",
+			Field:      "Foo",
 			FieldAlias: "foo",
-			Type: Slice,
-			Versions: []string{"1"},
+			Type:       Slice,
+			Versions:   []string{"1"},
 			Rules: NewRules((*string)(nil),
 				&Rule{
 					Type: String,
@@ -1004,7 +1004,7 @@ func TestApplyInboundRulesNestedRulesUnableToCoerceToPrimitive(t *testing.T) {
 			),
 		},
 	)
-	expectedErr := fmt.Errorf("Unable to coerce slice to map[string]interface{}")
+	expectedErr := fmt.Errorf("Value does not match rule type, expecting: string, got: slice")
 
 	actual, err := applyInboundRules(payload, rules, "1")
 
@@ -1018,10 +1018,10 @@ func TestApplyInboundRulesNestedRules(t *testing.T) {
 	payload := Payload{"foo": []interface{}{"bar", "baz"}}
 	rules := NewRules((*TestResourceSlice)(nil),
 		&Rule{
-			Field: "Foo",
+			Field:      "Foo",
 			FieldAlias: "foo",
-			Type: Slice,
-			Versions: []string{"1"},
+			Type:       Slice,
+			Versions:   []string{"1"},
 			Rules: NewRules((*string)(nil),
 				&Rule{
 					Type: String,


### PR DESCRIPTION
Adding support for nested rules on primitives in a slice. This will allow defining a type on a primitive so that go-rest coerces to the rule type instead of being tied to JSON types.

usage:

 ```go
&Rule{
	Field: "Foo",
	FieldAlias: "foo",
	Type: Slice,
	Rules: NewRules((*string)(nil), //pass a pointer to a primitive type
		&Rule{
			Type: String, //define type to coerce to
		},
	),
},
 ```