### PR TITLE
Close Response Body In Client

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -111,6 +111,7 @@ var do = func(c *http.Client, method, url string, body interface{}, header http.
 	if err != nil {
 		return nil, err
 	}
+	resp.Body.Close()
 
 	return decodeResponse(rawResp, resp)
 }


### PR DESCRIPTION
@tannermiller-wf @tylertreat-wf 

Without doing so, the underlying connection may not be closed.