### PR TITLE
Guard agains null array member input causing panic

### DIFF
--- a/rest/rule.go
+++ b/rest/rule.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rest
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -343,7 +344,7 @@ func applyNestedInboundRules(
 		for i := 0; i < s.Len(); i++ {
 			val := s.Index(i).Interface()
 			if val == nil {
-				return nil, fmt.Errorf("nested value is nil")
+				return nil, errors.New("nested value is nil")
 			}
 			// Check to see if the nested type is a slice or map.
 			// If not, it should be coerced to its rule type.

--- a/rest/rule.go
+++ b/rest/rule.go
@@ -341,9 +341,13 @@ func applyNestedInboundRules(
 		s := reflect.ValueOf(value)
 		nestedValues := make([]interface{}, s.Len())
 		for i := 0; i < s.Len(); i++ {
+			val := s.Index(i).Interface()
+			if val == nil {
+				return nil, fmt.Errorf("nested value is nil")
+			}
 			// Check to see if the nested type is a slice or map.
 			// If not, it should be coerced to its rule type.
-			iKind := reflect.TypeOf(s.Index(i).Interface()).Kind()
+			iKind := reflect.TypeOf(val).Kind()
 			ruleType := rules.Contents()[0].Type
 			if ruleKind := typeToKind[ruleType]; iKind == reflect.Slice && ruleKind != reflect.Slice {
 				return nil, fmt.Errorf("Value does not match rule type, expecting: %v, got: %v", ruleKind, iKind)

--- a/rest/rule_test.go
+++ b/rest/rule_test.go
@@ -1073,6 +1073,30 @@ func TestApplyInboundRulesNestedRulesDifferentVersion(t *testing.T) {
 	assert.Nil(err, "Error should be nil")
 }
 
+// Ensures that nested rules throw an error if a member is nil.
+func TestApplyInboundRulesNestedRulesNilMember(t *testing.T) {
+	assert := assert.New(t)
+	payload := Payload{"foo": []interface{}{nil}}
+	rules := NewRules((*TestResourceSlice)(nil),
+		&Rule{
+			Field:      "Foo",
+			FieldAlias: "foo",
+			Type:       Slice,
+			Versions:   []string{"1"},
+			Rules: NewRules((*string)(nil),
+				&Rule{
+					Type: String,
+				},
+			),
+		},
+	)
+
+	actual, err := applyInboundRules(payload, rules, "1")
+
+	assert.Nil(actual, "Payload should be nil")
+	assert.NotNil(err, "Error should not be nil")
+}
+
 // Ensures that non-resource Rules are applied correctly.
 func TestApplyInboundRulesNonResourceRule(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
Problem
=======
If you have nested rules that expect an array of objects, like so:

```javascript
"stuff": [
	{"foo": "bar1"},
	{"foo": "bar2"}
]
```

a `null` array member will cause a panic:

```javascript
"stuff": [null]
```

Solution
======
Check for `nil` values and throw an error.

Code Review
=====
@alexandercampbell-wf @tylertreat-wf 
