### PR TITLE
Consume smithy-runner 3.5.5

### DIFF
--- a/smithy.yml
+++ b/smithy.yml
@@ -1,5 +1,6 @@
 project: go-rest
 language: go
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner:112206
 
 script:
   - echo "Just using Smithy for dependency scanning"


### PR DESCRIPTION
In order to keep builds deterministic, and reduce the risk of future build failure, please pin your smithy runner to the currently defaulted runner.
For more information please see the email 'Smithy Runner Recommendation' or reach out to Travis Reed in hipchat.


Requested by: @travisreed-wf

@travisreed-wf