### PR TITLE
RM-16227 Add path trimming middleware with unit tests

### DIFF
--- a/rest/middleware/path_trim.go
+++ b/rest/middleware/path_trim.go
@@ -8,8 +8,8 @@ import(
 )
 
 // NewPathTrimMiddleware returns a Middleware which inspects request paths
-// and removes the content of trimPortion from them. With a path of /foo/bar/
-// and a trimpPortion of /foo you would be left with a path of /bar/.
+// and removes the content of trimPortion from the prefix. With a path of /foo/bar
+// and a trimpPortion of /foo you would be left with a path of /bar.
 func NewPathTrimMiddleware(trimPortion string) rest.Middleware {
 	return func(w http.ResponseWriter, r *http.Request) *rest.MiddlewareError {
 		r.URL.Path = strings.TrimPrefix(r.URL.Path, trimPortion)

--- a/rest/middleware/path_trim.go
+++ b/rest/middleware/path_trim.go
@@ -1,0 +1,18 @@
+package middleware
+
+import(
+	"net/http"
+	"strings"
+
+	"github.com/Workiva/go-rest/rest"
+)
+
+// NewPathTrimMiddleware returns a Middleware which inspects request paths
+// and removes the content of trimPortion from them. With a path of /foo/bar/
+// and a trimpPortion of /foo you would be left with a path of /bar/.
+func NewPathTrimMiddleware(trimPortion string) rest.Middleware {
+	return func(w http.ResponseWriter, r *http.Request) *rest.MiddlewareError {
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, trimPortion)
+		return nil
+	}
+}

--- a/rest/middleware/path_trim_test.go
+++ b/rest/middleware/path_trim_test.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Ensure that PathTrimMiddleware is correctly trimming the request path
+func TestPathTrimMiddlewareTrimPrefix(t *testing.T) {
+	assert := assert.New(t)
+	req, _ := http.NewRequest("GET", "http://example.com/foo/bar", nil)
+	w := httptest.NewRecorder()
+
+	assert.Nil(NewPathTrimMiddleware("/foo")(w, req))
+	assert.Equal(req.URL.Path, "/bar")
+}
+
+// Ensure that PathTrimMiddleware correclty passes a path that doesn't need 
+// to be trimmed
+func TestPathTrimMiddlewareNoTrimPrefix(t *testing.T) {
+	assert := assert.New(t)
+	req, _ := http.NewRequest("GET", "http://example.com/foo/bar", nil)
+	w := httptest.NewRecorder()
+
+	assert.Nil(NewPathTrimMiddleware("/baz")(w, req))
+	assert.Equal(req.URL.Path, "/foo/bar")
+}


### PR DESCRIPTION
This adds a middleware that will trim the provided prefix from request paths.

For example initialized with a trim of '/foo' the path '/foo/bar' will be trimmed to '/bar'

@brianshannan-wf @stevenosborne-wf 